### PR TITLE
ci: add code generation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if git diff --cached --name-only | grep 'gen\.go'; then
+  echo "cannot commit generated files"
+  exit 1
+fi
+
+exit 0

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,0 +1,31 @@
+name: generate.yaml
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: generate
+        run: |
+          go generate ./...
+
+      - name: Commit generated files
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          
+          find . -name '*gen.go' -print0 | xargs -0 git add -f
+          git commit -m "chore: commit generated files" || echo "No changes to commit"
+          git push origin main


### PR DESCRIPTION
This pull request introduces changes to automate the handling of generated files and prevent accidental commits of such files. The key updates include adding a pre-commit hook to block commits of generated files and creating a GitHub workflow to automatically generate and commit these files to the `main` branch.

### Automation of handling generated files:

* [`.githooks/pre-commit`](diffhunk://#diff-87320095d7c4f39eed5d8f3866b512eb910e4eec8e7926faaeef6a53ab786fcbR1-R8): Added a pre-commit hook that checks for staged files matching the pattern `gen.go` and prevents them from being committed, ensuring generated files are not manually committed.

* [`.github/workflows/generate.yaml`](diffhunk://#diff-bcd496d639a499ef595f8d0738bd8f9971cc2bb46f4c5b2ef964b13b15425508R1-R31): Added a GitHub Actions workflow that automatically generates files using `go generate`, commits them with a predefined user configuration, and pushes the changes to the `main` branch. This ensures generated files are consistently updated and committed in an automated manner.